### PR TITLE
Refactor style collectors to stop using the elementName getter

### DIFF
--- a/.storybook/Misc.tsx
+++ b/.storybook/Misc.tsx
@@ -1,21 +1,24 @@
 import { storiesOf } from '@storybook/react';
-import React, { FC, Fragment, useState, useEffect } from 'react';
+import React, {
+    FC,
+    Fragment,
+    useState,
+    useEffect,
+    MouseEventHandler,
+} from 'react';
 
-import { css, styleCollector, useStyles } from '../src';
+import { css, styleCollector, useStyles, ThemeProvider } from '../src';
 
 storiesOf('Miscellaneous', module)
     .add('State transitions', () => {
-        const logoStyles = styleCollector('logo').element`
-                    width: 150px;
-                    height: auto;
-                    margin: 15px;
-                    padding: 15px;
-                    background-color: #b3cde8;
-                    border-radius: 150px;
-                    animation: rotating 2s linear infinite;
-                    transition: background-color linear 300ms;
-                    cursor: pointer;
-                `;
+        const logoStyles = css`
+            width: 150px;
+            height: auto;
+            margin: 15px;
+            padding: 15px;
+            background-color: #b3cde8;
+            border-radius: 150px;
+        `;
 
         const TrousersLogo: FC = () => {
             const [count, setCount] = useState(0);
@@ -41,9 +44,120 @@ storiesOf('Miscellaneous', module)
 
         return <TrousersLogo />;
     })
+    .add('Alternating style collectors', () => {
+        const logoStyles = css`
+            width: 150px;
+            height: auto;
+            margin: 15px;
+            padding: 15px;
+            background-color: #b3cde8;
+            border-radius: 150px;
+        `;
+
+        const logoStylesAlt = css`
+            width: 150px;
+            height: auto;
+            margin: 15px;
+            padding: 15px;
+            background-color: #f6e3e3;
+        `;
+
+        const TrousersLogo: FC = () => {
+            const [count, setCount] = useState(0);
+            const [styleCollector, setStyleCollector] = useState(logoStylesAlt);
+            const logoClassnames = useStyles(styleCollector);
+
+            useEffect(() => {
+                const ts = setTimeout(() => {
+                    const nextTick = count + 1;
+
+                    setStyleCollector(
+                        nextTick % 2 ? logoStyles : logoStylesAlt,
+                    );
+
+                    setCount(nextTick);
+                }, 1000);
+
+                return () => clearTimeout(ts);
+            });
+
+            return (
+                <Fragment>
+                    <p>{count}</p>
+                    <img
+                        className={logoClassnames}
+                        src="trousers-logo.png"
+                        alt={`Trousers Logo ${count}`}
+                    />
+                </Fragment>
+            );
+        };
+
+        return <TrousersLogo />;
+    })
+    .add('Alternating themes', () => {
+        interface Theme {
+            primaryColor: string;
+        }
+
+        const lightTheme: Theme = {
+            primaryColor: '#b3cde8',
+        };
+
+        const darkTheme: Theme = {
+            primaryColor: '#f6e3e3',
+        };
+
+        const logoStyles = css<Theme>`
+            width: 150px;
+            height: auto;
+            margin: 15px;
+            padding: 15px;
+            background-color: ${theme => theme.primaryColor};
+            border-radius: 150px;
+        `;
+
+        const TrousersLogo: FC = () => {
+            const logoClassnames = useStyles(logoStyles);
+
+            return (
+                <img
+                    className={logoClassnames}
+                    src="trousers-logo.png"
+                    alt={`Trousers Logo`}
+                />
+            );
+        };
+        const Alternator: FC = () => {
+            const [count, setCount] = useState(0);
+            const [theme, setTheme] = useState(darkTheme);
+
+            useEffect(() => {
+                const ts = setTimeout(() => {
+                    const nextTick = count + 1;
+                    console.log(nextTick);
+
+                    setTheme(nextTick % 2 ? lightTheme : darkTheme);
+                    setCount(nextTick);
+                }, 1000);
+
+                return () => clearTimeout(ts);
+            });
+
+            return (
+                <ThemeProvider theme={theme}>
+                    <p>{count}</p>
+                    <TrousersLogo />
+                </ThemeProvider>
+            );
+        };
+
+        return <Alternator />;
+    })
     .add('Mount/Dismount', () => {
         interface LogoProps {
             primary?: boolean;
+            onClick: MouseEventHandler;
         }
 
         const logoStyles = styleCollector<LogoProps>('logo').element`
@@ -66,6 +180,7 @@ storiesOf('Miscellaneous', module)
             return (
                 <img
                     className={classNames}
+                    onClick={e => props.onClick(e)}
                     src="trousers-logo.png"
                     alt={`Trousers Logo`}
                 />
@@ -78,43 +193,13 @@ storiesOf('Miscellaneous', module)
             return (
                 <Fragment>
                     {!active ? (
-                        <div onClick={() => setActive(true)}>
-                            <Logo />
-                        </div>
+                        <Logo onClick={() => setActive(true)} />
                     ) : (
-                        <div onClick={() => setActive(false)}>
-                            <Logo primary />
-                        </div>
+                        <Logo primary onClick={() => setActive(false)} />
                     )}
                 </Fragment>
             );
         };
 
         return <Toggle />;
-    })
-    .add('CSS function as element', () => {
-        const styles = css`
-            background-color: #b3cde8;
-            border-radius: 150px;
-            color: white;
-            font: 500 20px sans-serif;
-            height: auto;
-            letter-spacing: 1px;
-            margin: 15px;
-            padding: 15px;
-            width: 350px;
-            text-align: center;
-        `;
-
-        const Element: FC = () => {
-            const className = useStyles(styles);
-
-            return (
-                <div className={className}>
-                    I am styled with plain CSS function
-                </div>
-            );
-        };
-
-        return <Element />;
     });

--- a/src/__snapshots__/index.spec.tsx.snap
+++ b/src/__snapshots__/index.spec.tsx.snap
@@ -13,10 +13,9 @@ Array [
     *{background-color:red;}
   </style>,
   <style
-    data-trousers=".button__11079579703130397219,.button--26780284923130397219"
+    data-trousers=".button__11079579703130397219"
   >
     .button__11079579703130397219{background-color:#b3cde8;color:white;}
-.button--26780284923130397219{background-color:#f95b5b;color:#ffffff;}
   </style>,
 ]
 `;

--- a/src/css.spec.ts
+++ b/src/css.spec.ts
@@ -6,7 +6,7 @@ describe('css', () => {
             font-style: normal;
         `;
 
-        expect(collector.getElementName()).toEqual('css');
+        expect(collector.get()[0].name).toEqual('css__');
     });
 
     it('registers styles', () => {

--- a/src/css.ts
+++ b/src/css.ts
@@ -3,7 +3,6 @@ import { Expression, StyleDefinition } from './types';
 
 export interface SingleStyleCollector<Theme> {
     get: () => StyleDefinition<{}, {}, Theme>[];
-    getElementName: () => string;
 }
 
 export default function css<Theme = {}>(
@@ -16,6 +15,5 @@ export default function css<Theme = {}>(
 
     return {
         get: () => styleCollector.get(),
-        getElementName: () => styleCollector.getElementName(),
     };
 }

--- a/src/style-collector.spec.ts
+++ b/src/style-collector.spec.ts
@@ -2,9 +2,9 @@ import styleCollector from './style-collector';
 
 describe('styleCollector', () => {
     it('returns the correct element name', () => {
-        const collector = styleCollector('my-element-name');
+        const collector = styleCollector('my-element-name').element``;
 
-        expect(collector.getElementName()).toEqual('my-element-name');
+        expect(collector.get()[0].name).toEqual('my-element-name__');
     });
 
     it('registers an element', () => {
@@ -24,9 +24,11 @@ describe('styleCollector', () => {
                 font-style: bold;
             `;
 
-        expect(collector.get().length).toBe(2);
-        expect(collector.get()[1].hash).toEqual('2064733655');
-        expect(collector.get()[1].predicate({ isBold: true })).toBe(true);
+        const styleDefinitions = collector.get();
+
+        expect(styleDefinitions.length).toBe(2);
+        expect(styleDefinitions[1].hash).toEqual('2064733655');
+        expect(styleDefinitions[1].predicate({ isBold: true })).toBe(true);
     });
 
     it('registers an element and named modifier', () => {
@@ -37,9 +39,11 @@ describe('styleCollector', () => {
                 font-style: bold;
             `;
 
-        expect(collector.get().length).toBe(2);
-        expect(collector.get()[1].hash).toEqual('bold2064733655');
-        expect(collector.get()[1].predicate({ isBold: true })).toBe(true);
+        const styleDefinitions = collector.get();
+
+        expect(styleDefinitions.length).toBe(2);
+        expect(styleDefinitions[1].hash).toEqual('bold2064733655');
+        expect(styleDefinitions[1].predicate({ isBold: true })).toBe(true);
     });
 
     it('registers an element and multiple modifiers', () => {
@@ -56,9 +60,11 @@ describe('styleCollector', () => {
                 font-style: italic;
             `;
 
-        expect(collector.get().length).toBe(3);
-        expect(collector.get()[0].hash).toEqual('2111092729');
-        expect(collector.get()[1].hash).toEqual('2064733655');
-        expect(collector.get()[2].hash).toEqual('2172502402');
+        const styleDefinitions = collector.get();
+
+        expect(styleDefinitions.length).toBe(3);
+        expect(styleDefinitions[0].hash).toEqual('2111092729');
+        expect(styleDefinitions[1].hash).toEqual('2064733655');
+        expect(styleDefinitions[2].hash).toEqual('2172502402');
     });
 });

--- a/src/style-collector.ts
+++ b/src/style-collector.ts
@@ -7,7 +7,11 @@ export class StyleCollector<Props, State, Theme> {
     constructor(private elementName: string) {}
 
     element(styles: TemplateStringsArray, ...expressions: Expression<Theme>[]) {
-        return this.registerStyles(styles, expressions, '__');
+        return this.registerStyles(
+            styles,
+            expressions,
+            `${this.elementName}__`,
+        );
     }
 
     modifier(
@@ -40,11 +44,14 @@ export class StyleCollector<Props, State, Theme> {
         return (
             styles: TemplateStringsArray,
             ...expressions: Expression<Theme>[]
-        ) => this.registerStyles(styles, expressions, '--', predicate, id);
-    }
-
-    getElementName() {
-        return this.elementName;
+        ) =>
+            this.registerStyles(
+                styles,
+                expressions,
+                `${this.elementName}--`,
+                predicate,
+                id,
+            );
     }
 
     get() {
@@ -60,7 +67,7 @@ export class StyleCollector<Props, State, Theme> {
     private registerStyles(
         styles: TemplateStringsArray,
         expressions: Expression<Theme>[],
-        separator: string,
+        name: string,
         predicate: Predicate<Props, State> = () => true,
         id: string = '',
     ) {
@@ -71,7 +78,7 @@ export class StyleCollector<Props, State, Theme> {
             styles,
             expressions,
             predicate,
-            separator,
+            name,
         });
 
         return this;

--- a/src/types/style-definition.ts
+++ b/src/types/style-definition.ts
@@ -13,5 +13,5 @@ export interface StyleDefinition<Props, State, Theme>
     extends TaggedTemplate<Theme> {
     hash: string;
     predicate: Predicate<Props, State>;
-    separator?: string;
+    name: string;
 }


### PR DESCRIPTION

- (refactor): Removes the `elementName` getter, in favour of a name property on the style defintion
- (docs): Minor changes to the misc storybook example