### PR TITLE
💥 Disallows prop and state passing through styleCollectors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ lib
 dist
 .site
 .DS_Store
+.vscode
 storybook-static

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ A themed button with a _primary_ variant:
 ```jsx
 import { styleCollector, useStyles } from 'trousers';
 
-const styles = styleCollector('button').element`
+const styles = props => styleCollector('button').element`
         background-color: ${theme => theme.backgroundColor};
         border: none;
         color: ${theme => theme.textColor};
@@ -63,7 +63,7 @@ const styles = styleCollector('button').element`
             background-color: ${theme => theme.hoverColor};
             color: rgba(255, 255, 255, 0.8);
         }
-    `.modifier('primary', props => !!props.primary)`
+    `.modifier('primary', !!props.primary)`
         background-color: #f95b5b;
         color: #ffffff;
 
@@ -73,7 +73,7 @@ const styles = styleCollector('button').element`
     `;
 
 const Button = props => {
-    const buttonClassNames = useStyles(styles, props);
+    const buttonClassNames = useStyles(styles(props));
 
     return <button className={buttonClassNames}>{props.children}</button>;
 };
@@ -156,14 +156,9 @@ For example, here we define a style for the button and inner span and apply the 
 
 ```jsx
 const Button = props => {
-    const buttonClassNames = useStyles(buttonStyles, props);
-    const spanClassNames = useStyles(spanStyles, props);
+    const buttonClassNames = useStyles(buttonStyles(props));
 
-    return (
-        <button className={buttonClassNames}>
-            <span className={spanClassNames}>{props.children}</span>
-        </button>
-    );
+    return <button className={buttonClassNames}>{props.children}</button>;
 };
 ```
 
@@ -205,11 +200,11 @@ When a Trousers component is mounted within a new theme context, it will render 
 You can define how your component handles themes like this:
 
 ```jsx
-const buttonStyles = styleCollector('button').element`
+const buttonStyles = props => styleCollector('button').element`
         background-color: ${theme => theme.secondaryColor};
-    `.modifier(props => props.primary)`
+    `.modifier(props.primary)`
         background-color: ${theme => theme.primaryColor};
-    `.modifier(props => props.disabled)`
+    `.modifier(props.disabled)`
         background-color: ${theme => theme.disabledColor};
     `;
 ```
@@ -333,17 +328,13 @@ Modifiers follow the same methodology as [Modifiers in BEM](https://en.bem.info/
 ```jsx
 import { styleCollector } from 'trousers';
 
-const styles = styleCollector('button').element``.modifier(props => {
-    return props.primary;
-})`
+const styles = (props, state) => styleCollector('button').element``.modifier(
+    props.primary,
+)`
         background-color: yellow;
-    `.modifier('active', (props, state) => {
-    return state.isActive;
-})`
+    `.modifier('active', state.isActive)`
         background-color: purple;
-    `.modifier('disabled', props => {
-    return props.isDisabled;
-})`
+    `.modifier('disabled', props.isDisabled)`
         background-color: grey;
     `;
 ```
@@ -398,12 +389,12 @@ React Hook responsbile for evaluating the supplied styles, attaching them to the
 import React from 'react';
 import { styleCollector, useStyles } from 'trousers';
 
-const styles = styleCollector('button')
+const styles = props => styleCollector('button')
     .element``
     .modifier(...)``;
 
 const Button = props => {
-    const classNames = useStyles(styles, props);
+    const classNames = useStyles(styles(props));
 
     return (
         <button className={classNames}>
@@ -424,17 +415,13 @@ Use this HOC in your class components, where hooks (and useStyles) are not avail
 **Arguments:**
 
 -   `Component`: React Component
--   `styleCollector`: StyleCollector
+-   `(props) => styleCollector`: Function returning a StyleCollector
 
 **Example:**
 
 ```jsx
 import React from 'react';
 import { styleCollector, withStyles } from 'trousers';
-
-const styles = styleCollector('button')
-    .element``
-    .modifier(true)``;
 
 class Button {
     render() {
@@ -447,7 +434,9 @@ class Button {
     }
 );
 
-export default withStyles(Button, styles);
+export default withStyles(Button, (props) => styleCollector('button')
+    .element``
+    .modifier(props.primary)``);
 ```
 
 ### `<ThemeProvider />`

--- a/examples/Basic.tsx
+++ b/examples/Basic.tsx
@@ -11,7 +11,8 @@ storiesOf('Basic', module)
             disabled?: boolean;
         }
 
-        const buttonStyles = styleCollector<ButtonProps>('button').element`
+        const buttonStyles = (props: ButtonProps) => styleCollector('button')
+            .element`
                 background-color: #b3cde8;
                 border-radius: 6px;
                 border: none;
@@ -21,6 +22,7 @@ storiesOf('Basic', module)
                 cursor: pointer;
                 font-family: sans-serif;
                 font-weight: 500;
+                font-size: 20px;
                 letter-spacing: 1px;
                 margin: 5px 10px;
                 padding: 10px 20px 14px 20px;
@@ -36,7 +38,7 @@ storiesOf('Basic', module)
                 :active {
                     background-color: #9fb8d1;
                 }
-            `.modifier(props => !!props!.primary)`
+            `.modifier(!!props.primary)`
                 background-color: #f95b5b;
                 box-shadow: inset 0 -4px #c54646;
                 color: #ffffff;
@@ -48,7 +50,7 @@ storiesOf('Basic', module)
                 :active {
                     background-color: #c54646;
                 }
-            `.modifier(props => !!props!.disabled)`
+            `.modifier(!!props.disabled)`
                 background-color: #efefef;
                 box-shadow: inset 0 -4px #afafaf;
                 color: #afafaf;
@@ -61,20 +63,11 @@ storiesOf('Basic', module)
                 }
             `;
 
-        const buttonSpanStyles = styleCollector('button-span').element`
-                font-size: 20px;
-            `;
-
         const Button: FC<ButtonProps> = props => {
-            const buttonClassNames = useStyles(buttonStyles, props);
-            const buttonSpanClassNames = useStyles(buttonSpanStyles);
+            const buttonClassNames = useStyles(buttonStyles(props));
 
             return (
-                <button className={buttonClassNames}>
-                    <span className={buttonSpanClassNames}>
-                        {props.children}
-                    </span>
-                </button>
+                <button className={buttonClassNames}>{props.children}</button>
             );
         };
 
@@ -94,7 +87,8 @@ storiesOf('Basic', module)
             isOn?: boolean;
         }
 
-        const toggleStyles = styleCollector<{}, ButtonState>('toggle').element`
+        const toggleStyles = (state: ButtonState) => styleCollector('toggle')
+            .element`
                 background-color: #b3cde8;
                 border-radius: 6px;
                 border: none;
@@ -118,7 +112,7 @@ storiesOf('Basic', module)
                 :active {
                     background-color: #9fb8d1;
                 }
-            `.modifier((props, state) => !!state!.isOn)`
+            `.modifier(!!state.isOn)`
                 background-color: #f95b5b;
                 box-shadow: inset 0 -4px #c54646;
                 color: #ffffff;
@@ -134,7 +128,7 @@ storiesOf('Basic', module)
 
         const Button: FC = () => {
             const [isOn, setToggle] = useState(false);
-            const buttonClassNames = useStyles(toggleStyles, {}, { isOn });
+            const buttonClassNames = useStyles(toggleStyles({ isOn }));
 
             return (
                 <button

--- a/examples/Misc.tsx
+++ b/examples/Misc.tsx
@@ -160,7 +160,9 @@ storiesOf('Miscellaneous', module)
             onClick: MouseEventHandler;
         }
 
-        const logoStyles = styleCollector<LogoProps>('logo').element`
+        const logoStyles = (props: LogoProps) => styleCollector<LogoProps>(
+            'logo',
+        ).element`
                 width: 150px;
                 height: auto;
                 margin: 15px;
@@ -170,12 +172,12 @@ storiesOf('Miscellaneous', module)
                 animation: rotating 2s linear infinite;
                 transition: background-color linear 300ms;
                 cursor: pointer;
-            `.modifier(props => !!props!.primary)`
+            `.modifier(!!props.primary)`
                 background-color: #f6e3e3;
             `;
 
         const Logo: FC<LogoProps> = props => {
-            const classNames = useStyles(logoStyles, props);
+            const classNames = useStyles(logoStyles(props));
 
             return (
                 <img

--- a/examples/Performance.tsx
+++ b/examples/Performance.tsx
@@ -36,7 +36,7 @@ storiesOf('Performance', module).add('Many of the same nodes', () => {
         `;
 
     const Button: FC<ButtonProps> = props => {
-        const buttonClassNames = useStyles(styles, props);
+        const buttonClassNames = useStyles(styles);
 
         return <button className={buttonClassNames}>{props.children}</button>;
     };

--- a/examples/Theme.tsx
+++ b/examples/Theme.tsx
@@ -28,7 +28,7 @@ interface ButtonProps {
     children: ReactNode;
 }
 
-const buttonStyles = styleCollector<ButtonProps, {}, Theme>('button').element`
+const buttonStyles = styleCollector<Theme>('button').element`
         background-color: ${({ backgroundColor }) => backgroundColor};
         border-radius: 6px;
         border: none;
@@ -56,7 +56,7 @@ const buttonStyles = styleCollector<ButtonProps, {}, Theme>('button').element`
     `;
 
 const Button: FC<ButtonProps> = props => {
-    const classNames = useStyles(buttonStyles, props);
+    const classNames = useStyles(buttonStyles);
 
     return <button className={classNames}>{props.children}</button>;
 };

--- a/src/css.ts
+++ b/src/css.ts
@@ -1,15 +1,15 @@
 import { StyleCollector } from './';
 import { Expression, StyleDefinition } from './types';
 
-export interface SingleStyleCollector<Theme> {
-    get: () => StyleDefinition<{}, {}, Theme>[];
+export interface SingleStyleCollector<Theme = {}> {
+    get: () => StyleDefinition<Theme>[];
 }
 
 export default function css<Theme = {}>(
     styles: TemplateStringsArray,
     ...expressions: Expression<Theme>[]
 ): SingleStyleCollector<Theme> {
-    const styleCollector = new StyleCollector<{}, {}, Theme>('css');
+    const styleCollector = new StyleCollector<Theme>('css');
 
     styleCollector.element(styles, ...expressions);
 

--- a/src/index.spec.tsx
+++ b/src/index.spec.tsx
@@ -30,7 +30,7 @@ interface Theme {
 }
 
 describe('Server side rendering (SSR)', () => {
-    let styles: StyleCollector<ButtonProps, {}, Theme>;
+    let styles: (props: ButtonProps) => StyleCollector<Theme>;
     let globalStyles: SingleStyleCollector<Theme>;
     let Button: FC<ButtonProps>;
     let theme: Theme;
@@ -47,16 +47,17 @@ describe('Server side rendering (SSR)', () => {
             }
         `;
 
-        styles = styleCollector<ButtonProps, {}, Theme>('button').element`
+        styles = (props: ButtonProps) => styleCollector<Theme>('button')
+            .element`
                 background-color: ${theme => theme.default};
                 color: white;
-            `.modifier(props => !!props!.primary)`
+            `.modifier(!!props.primary)`
                 background-color: ${theme => theme.primary};
                 color: #ffffff;
             `;
 
         Button = props => {
-            const classNames = useStyles(styles, props);
+            const classNames = useStyles(styles(props));
 
             return <button className={classNames}>{props.children}</button>;
         };

--- a/src/style-collector.spec.ts
+++ b/src/style-collector.spec.ts
@@ -17,33 +17,35 @@ describe('styleCollector', () => {
     });
 
     it('registers an element and modifier', () => {
-        const collector = styleCollector<{ isBold: boolean }>('myBlock')
-            .element`
+        const collector = (props: { isBold: boolean }) => styleCollector(
+            'myBlock',
+        ).element`
                 font-style: normal;
-            `.modifier(props => !!props!.isBold)`
+            `.modifier(!!props.isBold)`
                 font-style: bold;
             `;
 
-        const styleDefinitions = collector.get();
+        const styleDefinitions = collector({ isBold: true }).get();
 
         expect(styleDefinitions.length).toBe(2);
         expect(styleDefinitions[1].hash).toEqual('2064733655');
-        expect(styleDefinitions[1].predicate({ isBold: true })).toBe(true);
+        expect(styleDefinitions[1].predicate).toBe(true);
     });
 
     it('registers an element and named modifier', () => {
-        const collector = styleCollector<{ isBold: boolean }>('myBlock')
-            .element`
+        const collector = (props: { isBold: boolean }) => styleCollector(
+            'myBlock',
+        ).element`
                 font-style: normal;
-            `.modifier('bold', props => !!props!.isBold)`
+            `.modifier('bold', !!props.isBold)`
                 font-style: bold;
             `;
 
-        const styleDefinitions = collector.get();
+        const styleDefinitions = collector({ isBold: true }).get();
 
         expect(styleDefinitions.length).toBe(2);
         expect(styleDefinitions[1].hash).toEqual('bold2064733655');
-        expect(styleDefinitions[1].predicate({ isBold: true })).toBe(true);
+        expect(styleDefinitions[1].predicate).toBe(true);
     });
 
     it('registers an element and multiple modifiers', () => {
@@ -52,15 +54,18 @@ describe('styleCollector', () => {
             isItalic?: boolean;
         }
 
-        const collector = styleCollector<Props>('myBlock').element`
+        const collector = (props: Props) => styleCollector('myBlock').element`
                 font-style: normal;
-            `.modifier(props => !!props!.isBold)`
+            `.modifier(!!props.isBold)`
                 font-style: bold;
-            `.modifier(props => !!props!.isItalic)`
+            `.modifier(!!props.isItalic)`
                 font-style: italic;
             `;
 
-        const styleDefinitions = collector.get();
+        const styleDefinitions = collector({
+            isBold: true,
+            isItalic: true,
+        }).get();
 
         expect(styleDefinitions.length).toBe(3);
         expect(styleDefinitions[0].hash).toEqual('2111092729');

--- a/src/style-collector.ts
+++ b/src/style-collector.ts
@@ -1,8 +1,8 @@
 import { StyleDefinition, Predicate, Expression } from './types';
 import { generateHash } from './common';
 
-export class StyleCollector<Props, State, Theme> {
-    private styleDefinitions: StyleDefinition<Props, State, Theme>[] = [];
+export class StyleCollector<Theme = {}> {
+    private styleDefinitions: StyleDefinition<Theme>[] = [];
 
     constructor(private elementName: string) {}
 
@@ -15,7 +15,7 @@ export class StyleCollector<Props, State, Theme> {
     }
 
     modifier(
-        predicate: Predicate<Props, State>,
+        predicate: Predicate,
     ): (
         styles: TemplateStringsArray,
         ...expressions: Expression<Theme>[]
@@ -23,16 +23,13 @@ export class StyleCollector<Props, State, Theme> {
 
     modifier(
         id: string,
-        predicate: Predicate<Props, State>,
+        predicate: Predicate,
     ): (
         styles: TemplateStringsArray,
         ...expressions: Expression<Theme>[]
     ) => this;
 
-    modifier(
-        idOrPredicate: string | Predicate<Props, State>,
-        predicate?: Predicate<Props, State>,
-    ) {
+    modifier(idOrPredicate: string | Predicate, predicate?: Predicate) {
         let id: string;
 
         if (typeof idOrPredicate === 'string') {
@@ -68,7 +65,7 @@ export class StyleCollector<Props, State, Theme> {
         styles: TemplateStringsArray,
         expressions: Expression<Theme>[],
         name: string,
-        predicate: Predicate<Props, State> = () => true,
+        predicate: Predicate = true,
         id: string = '',
     ) {
         let hash = id + this.getHash(styles).toString();
@@ -85,8 +82,6 @@ export class StyleCollector<Props, State, Theme> {
     }
 }
 
-export default function styleCollector<Props = {}, State = {}, Theme = {}>(
-    elementName: string,
-) {
-    return new StyleCollector<Props, State, Theme>(elementName);
+export default function styleCollector<Theme = {}>(elementName: string) {
+    return new StyleCollector<Theme>(elementName);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export type Predicate<Props, State> = (props?: Props, state?: State) => boolean;
+export type Predicate = boolean;
 export type Expression<Theme> =
     | string
     | number
@@ -9,9 +9,8 @@ export interface TaggedTemplate<Theme> {
     expressions: Expression<Theme>[];
 }
 
-export interface StyleDefinition<Props, State, Theme>
-    extends TaggedTemplate<Theme> {
+export interface StyleDefinition<Theme> extends TaggedTemplate<Theme> {
     hash: string;
-    predicate: Predicate<Props, State>;
+    predicate: Predicate;
     name: string;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,0 @@
-export {
-    StyleDefinition,
-    TaggedTemplate,
-    Predicate,
-    Expression,
-} from './style-definition';

--- a/src/useStyles.spec.tsx
+++ b/src/useStyles.spec.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { render, cleanup } from '@testing-library/react';
 
-import { css, useStyles, ThemeProvider, styleCollector } from './';
+import { css, ThemeProvider, styleCollector } from './';
+import useStyles from './useStyles';
 
 interface Props {
     isRed?: boolean;
@@ -16,7 +17,7 @@ describe('useStyles', () => {
     });
 
     it('returns correct className', () => {
-        const styles = styleCollector<Props>('foo').element`
+        const styles = styleCollector('foo').element`
             background-color: blue;
         `;
 
@@ -34,14 +35,14 @@ describe('useStyles', () => {
     });
 
     it('returns correct classNames for multiple modifiers', () => {
-        const styles = styleCollector<Props>('foo').element`
+        const styles = (props: Props) => styleCollector('foo').element`
             background-color: blue;
-        `.modifier(props => !!props!.isRed)`
+        `.modifier(!!props.isRed)`
             background-color: red;
         `;
 
         const StyledComponent: React.FC<Props> = props => {
-            const classNames = useStyles(styles, props);
+            const classNames = useStyles(styles(props));
 
             return <span className={classNames}>Ahoy!</span>;
         };
@@ -62,16 +63,16 @@ describe('useStyles', () => {
     });
 
     it('returns correct classNames for multiple named modifiers', () => {
-        const styles = styleCollector<Props>('foo').element`
+        const styles = (props: Props) => styleCollector('foo').element`
             background-color: blue;
-        `.modifier('primary', props => !!props!.isRed)`
+        `.modifier('primary', !!props.isRed)`
             background-color: red;
-        `.modifier('secondary', props => !!props!.isBlue)`
+        `.modifier('secondary', !!props.isBlue)`
             background-color: isBlue;
         `;
 
         const StyledComponent: React.FC<Props> = props => {
-            const classNames = useStyles(styles, props);
+            const classNames = useStyles(styles(props));
 
             return <span className={classNames}>Ahoy!</span>;
         };
@@ -108,7 +109,7 @@ describe('useStyles', () => {
     });
 
     it('attaches styles to the head', () => {
-        const styles = styleCollector<Props>('foo').element`
+        const styles = styleCollector('foo').element`
             background-color: blue;
         `;
 
@@ -124,14 +125,14 @@ describe('useStyles', () => {
     });
 
     it('attaches styles with modifiers to the head', () => {
-        const styles = styleCollector<Props>('foo').element`
+        const styles = (props: Props) => styleCollector('foo').element`
             background-color: blue;
-        `.modifier(props => !!props!.isRed)`
+        `.modifier(!!props.isRed)`
             background-color: red;
         `;
 
         const StyledComponent: React.FC<Props> = props => {
-            const classNames = useStyles(styles, props);
+            const classNames = useStyles(styles(props));
 
             return <span className={classNames}>Ahoy!</span>;
         };
@@ -146,14 +147,14 @@ describe('useStyles', () => {
     });
 
     it('attaches styles with named modifiers to the head', () => {
-        const styles = styleCollector<Props>('foo').element`
+        const styles = (props: Props) => styleCollector('foo').element`
             background-color: blue;
-        `.modifier('primary', props => !!props!.isRed)`
+        `.modifier('primary', !!props.isRed)`
             background-color: red;
         `;
 
         const StyledComponent: React.FC<Props> = props => {
-            const classNames = useStyles(styles, props);
+            const classNames = useStyles(styles(props));
 
             return <span className={classNames}>Ahoy!</span>;
         };
@@ -168,16 +169,16 @@ describe('useStyles', () => {
     });
 
     it('attaches styles with multiple named modifiers to the head', () => {
-        const styles = styleCollector<Props>('foo').element`
+        const styles = (props: Props) => styleCollector('foo').element`
             background-color: blue;
-        `.modifier('primary', props => !!props!.isRed)`
+        `.modifier('primary', !!props.isRed)`
             background-color: red;
-        `.modifier('secondary', props => !!props!.isBlue)`
+        `.modifier('secondary', !!props.isBlue)`
             background-color: isBlue;
         `;
 
         const StyledComponent: React.FC<Props> = props => {
-            const classNames = useStyles(styles, props);
+            const classNames = useStyles(styles(props));
 
             return <span className={classNames}>Ahoy!</span>;
         };
@@ -210,14 +211,14 @@ describe('useStyles', () => {
             backgroundColorSecondary: 'green',
         };
 
-        const styles = styleCollector<Props, {}, Theme>('foo').element`
+        const styles = (props: Props) => styleCollector<Theme>('foo').element`
             background-color: ${theme => theme.backgroundColor};
-        `.modifier(props => !!props!.isRed)`
+        `.modifier(!!props.isRed)`
             background-color: ${theme => theme.backgroundColor};
         `;
 
         const StyledComponent: React.FC<Props> = props => {
-            const classNames = useStyles(styles, props);
+            const classNames = useStyles(styles(props));
 
             return <span className={classNames}>Ahoy!</span>;
         };
@@ -246,13 +247,13 @@ describe('useStyles', () => {
 
         const styles = styleCollector<ToggleProps>('foo').element`
             background-color: blue;
-        `.modifier(() => true)`
+        `.modifier(true)`
             background-color: red;
         `;
 
-        const stylesAlt = styleCollector<ToggleProps>('foo').element`
+        const stylesAlt = styleCollector('foo').element`
             background-color: purple;
-        `.modifier(() => true)`
+        `.modifier(true)`
             background-color: green;
         `;
 
@@ -263,7 +264,7 @@ describe('useStyles', () => {
                 activeStyles = stylesAlt;
             }
 
-            const classNames = useStyles(activeStyles, props);
+            const classNames = useStyles(activeStyles);
 
             return <span className={classNames}>Ahoy!</span>;
         };

--- a/src/useStyles.ts
+++ b/src/useStyles.ts
@@ -9,16 +9,16 @@ import { SingleStyleCollector } from './css';
 import { ThemeContext, ThemeCtx } from './ThemeContext';
 import { ServerContext, ServerCtx } from './ServerContext';
 
-function getComponentId<Props, State, Theme>(
-    styleDefinition: StyleDefinition<Props, State, Theme>,
+function getComponentId<Theme>(
+    styleDefinition: StyleDefinition<Theme>,
     themeCtx: ThemeCtx,
 ) {
     return `${styleDefinition.name}${styleDefinition.hash}${themeCtx.hash ||
         ''}`;
 }
 
-function registerStyle<Props, State, Theme>(
-    styleDefinition: StyleDefinition<Props, State, Theme>,
+function registerStyle<Theme>(
+    styleDefinition: StyleDefinition<Theme>,
     registry: StyleRegistry | ServerStyleRegistry,
     themeCtx: ThemeCtx,
 ) {
@@ -36,21 +36,15 @@ function registerStyle<Props, State, Theme>(
     }
 }
 
-export default function useStyles<Props = {}, State = {}, Theme = {}>(
-    styleCollector:
-        | StyleCollector<Props, State, Theme>
-        | SingleStyleCollector<Theme>,
-    props?: Props,
-    state?: State,
+export default function useStyles<Theme = {}>(
+    styleCollector: StyleCollector<Theme> | SingleStyleCollector<Theme>,
 ) {
     const themeCtx = useContext<ThemeCtx>(ThemeContext);
     const serverStyleRegistry = useContext<ServerCtx>(ServerContext);
 
     const styleDefinitions = useMemo(() => {
-        return styleCollector
-            .get()
-            .filter(({ predicate }) => predicate(props, state));
-    }, [styleCollector, props, state]);
+        return styleCollector.get().filter(({ predicate }) => !!predicate);
+    }, [styleCollector]);
 
     if (!isBrowser() && !serverStyleRegistry) {
         throw Error(

--- a/src/withStyles.spec.tsx
+++ b/src/withStyles.spec.tsx
@@ -21,13 +21,16 @@ describe('withStyles', () => {
     });
 
     it('returns correct className', () => {
-        const styles = styleCollector<Props>('foo').element`
+        const styles = styleCollector('foo').element`
             background-color: blue;
         `;
 
-        const StyledComponent = withStyles(({ className }) => {
-            return <span className={className}>Ahoy!</span>;
-        }, styles);
+        const StyledComponent = withStyles(
+            ({ className }) => {
+                return <span className={className}>Ahoy!</span>;
+            },
+            () => styles,
+        );
 
         const { container } = render(<StyledComponent />);
 
@@ -37,15 +40,18 @@ describe('withStyles', () => {
     });
 
     it('returns correct classNames for multiple modifiers', () => {
-        const styles = styleCollector<Props>('foo').element`
+        const styles = (props: Props) => styleCollector('foo').element`
             background-color: blue;
-        `.modifier(props => !!props!.isRed)`
+        `.modifier(!!props.isRed)`
             background-color: red;
         `;
 
-        const StyledComponent = withStyles(({ className }) => {
-            return <span className={className}>Ahoy!</span>;
-        }, styles);
+        const StyledComponent = withStyles(
+            ({ className }: Props) => {
+                return <span className={className}>Ahoy!</span>;
+            },
+            props => styles(props),
+        );
 
         const { container } = render(<StyledComponent />);
 
@@ -63,13 +69,16 @@ describe('withStyles', () => {
     });
 
     it('attaches styles to the head', () => {
-        const styles = styleCollector<Props>('foo').element`
+        const styles = styleCollector('foo').element`
             background-color: blue;
         `;
 
-        const StyledComponent = withStyles(({ className }) => {
-            return <span className={className}>Ahoy!</span>;
-        }, styles);
+        const StyledComponent = withStyles(
+            ({ className }) => {
+                return <span className={className}>Ahoy!</span>;
+            },
+            () => styles,
+        );
 
         render(<StyledComponent />);
 
@@ -77,15 +86,18 @@ describe('withStyles', () => {
     });
 
     it('attaches styles with modifiers to the head', () => {
-        const styles = styleCollector<Props>('foo').element`
+        const styles = (props: Props) => styleCollector('foo').element`
             background-color: blue;
-        `.modifier(props => !!props!.isRed)`
+        `.modifier(!!props.isRed)`
             background-color: red;
         `;
 
-        const StyledComponent = withStyles(({ className }) => {
-            return <span className={className}>Ahoy!</span>;
-        }, styles);
+        const StyledComponent = withStyles(
+            ({ className }: Props) => {
+                return <span className={className}>Ahoy!</span>;
+            },
+            props => styles(props),
+        );
 
         render(<StyledComponent />);
 
@@ -107,15 +119,18 @@ describe('withStyles', () => {
             backgroundColorSecondary: 'green',
         };
 
-        const styles = styleCollector<Props, {}, Theme>('foo').element`
+        const styles = (props: Props) => styleCollector<Theme>('foo').element`
             background-color: ${theme => theme.backgroundColor};
-        `.modifier(props => !!props!.isRed)`
+        `.modifier(!!props.isRed)`
             background-color: ${theme => theme.backgroundColor};
         `;
 
-        const StyledComponent = withStyles(({ className }) => {
-            return <span className={className}>Ahoy!</span>;
-        }, styles);
+        const StyledComponent = withStyles<Props, Theme>(
+            ({ className }) => {
+                return <span className={className}>Ahoy!</span>;
+            },
+            props => styles(props),
+        );
 
         render(
             <ThemeProvider theme={theme}>
@@ -135,9 +150,9 @@ describe('withStyles', () => {
     });
 
     it('attaches single style to the head', () => {
-        const StyledComponent = withStyles<Props>(
-            ({ className }) => <span className={className}>Ahoy!</span>,
-            css`
+        const StyledComponent = withStyles(
+            ({ className }: Props) => <span className={className}>Ahoy!</span>,
+            () => css`
                 background-color: blue;
             `,
         );
@@ -158,7 +173,7 @@ describe('withStyles', () => {
 
         const StyledComponent = withStyles<Props, Theme>(
             ({ className }) => <span className={className}>Ahoy!</span>,
-            css<Theme>`
+            () => css<Theme>`
                 background-color: ${theme => theme.backgroundColor};
             `,
         );

--- a/src/withStyles.tsx
+++ b/src/withStyles.tsx
@@ -12,12 +12,12 @@ const withStyles = <
     Theme = {}
 >(
     Component: React.ComponentType<Props>,
-    styleCollector:
-        | StyleCollector<Props, {}, Theme>
-        | SingleStyleCollector<Theme>,
+    styleCollector: (
+        props: Props,
+    ) => StyleCollector<Theme> | SingleStyleCollector<Theme>,
 ) => {
     const WrappedComponent: FC<Props> = props => {
-        const className = useStyles(styleCollector, props);
+        const className = useStyles(styleCollector(props));
 
         return <Component {...props} className={className} />;
     };


### PR DESCRIPTION
Props and state will no longer be passed through to `styleCollector` and `css` style collectors. 

**Why? 🤷‍♂️** 
This is bad because: 
- Restrictive to users who want to pass things that don't fit neatly into props and state
- Unnecessarily increases runtime
- Type safety was broken 

**What now? 🤔**
Instead of passing props & state through the hook, we must now wrap style collectors in a function and manually pass the props down like so: 

```javascript
const buttonStyles = (props: ButtonProps) => styleCollector('button')
            .element``
            .modifier(!!props.primary, ``);
```

**An aside**
Can we integrate this into the style collector directly? How would the API look?????

```javascript
const buttonStyles = styleCollector('button')
            .element``
            .modifier(props => !!props.primary, ``);

//....

const classNames = useStyles(styleCollector(props, state));
```

```javascript
const buttonStyles = styleCollector('button')
            .element``
            .modifier(meta => !!meta.primary, ``);

// or

const classNames = useStyles(styleCollector({ ...props, ...state}));
```

## TODO
- Update API Docs