### PR TITLE
Expand modifiers to be able to accept Boolean | null | undef

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ const styles = props => styleCollector('button').element`
             background-color: ${theme => theme.hoverColor};
             color: rgba(255, 255, 255, 0.8);
         }
-    `.modifier('primary', !!props.primary)`
+    `.modifier('primary', props.primary)`
         background-color: #f95b5b;
         color: #ffffff;
 

--- a/src/index.spec.tsx
+++ b/src/index.spec.tsx
@@ -51,7 +51,7 @@ describe('Server side rendering (SSR)', () => {
             .element`
                 background-color: ${theme => theme.default};
                 color: white;
-            `.modifier(!!props.primary)`
+            `.modifier(props.primary)`
                 background-color: ${theme => theme.primary};
                 color: #ffffff;
             `;

--- a/src/style-collector.spec.ts
+++ b/src/style-collector.spec.ts
@@ -21,7 +21,7 @@ describe('styleCollector', () => {
             'myBlock',
         ).element`
                 font-style: normal;
-            `.modifier(!!props.isBold)`
+            `.modifier(props.isBold)`
                 font-style: bold;
             `;
 
@@ -37,7 +37,7 @@ describe('styleCollector', () => {
             'myBlock',
         ).element`
                 font-style: normal;
-            `.modifier('bold', !!props.isBold)`
+            `.modifier('bold', props.isBold)`
                 font-style: bold;
             `;
 
@@ -56,9 +56,9 @@ describe('styleCollector', () => {
 
         const collector = (props: Props) => styleCollector('myBlock').element`
                 font-style: normal;
-            `.modifier(!!props.isBold)`
+            `.modifier(props.isBold)`
                 font-style: bold;
-            `.modifier(!!props.isItalic)`
+            `.modifier(props.isItalic)`
                 font-style: italic;
             `;
 

--- a/src/style-collector.ts
+++ b/src/style-collector.ts
@@ -11,6 +11,7 @@ export class StyleCollector<Theme = {}> {
             styles,
             expressions,
             `${this.elementName}__`,
+            true,
         );
     }
 
@@ -65,7 +66,7 @@ export class StyleCollector<Theme = {}> {
         styles: TemplateStringsArray,
         expressions: Expression<Theme>[],
         name: string,
-        predicate: Predicate = true,
+        predicate: Predicate,
         id: string = '',
     ) {
         let hash = id + this.getHash(styles).toString();
@@ -74,7 +75,7 @@ export class StyleCollector<Theme = {}> {
             hash,
             styles,
             expressions,
-            predicate,
+            predicate: !!predicate,
             name,
         });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export type Predicate = boolean;
+export type Predicate = boolean | undefined | null;
 export type Expression<Theme> =
     | string
     | number

--- a/src/useStyles.spec.tsx
+++ b/src/useStyles.spec.tsx
@@ -36,9 +36,11 @@ describe('useStyles', () => {
 
     it('returns correct classNames for multiple modifiers', () => {
         const styles = (props: Props) => styleCollector('foo').element`
-            background-color: blue;
-        `.modifier(!!props.isRed)`
+            background-color: green;
+        `.modifier(props.isRed)`
             background-color: red;
+        `.modifier(props.isBlue)`
+            background-color: blue;
         `;
 
         const StyledComponent: React.FC<Props> = props => {
@@ -47,27 +49,42 @@ describe('useStyles', () => {
             return <span className={classNames}>Ahoy!</span>;
         };
 
-        const { container } = render(<StyledComponent />);
+        {
+            const { container } = render(<StyledComponent />);
 
-        expect(container.querySelector('span')!.className).toEqual(
-            'foo__3889083325',
-        );
+            expect(container.querySelector('span')!.className).toEqual(
+                'foo__3826246206',
+            );
+        }
+        {
+            const { container } = render(<StyledComponent isRed />);
 
-        const { container: secondContainer } = render(
-            <StyledComponent isRed />,
-        );
+            expect(container.querySelector('span')!.className).toEqual(
+                'foo__3826246206 foo--491189580',
+            );
+        }
+        {
+            const { container } = render(<StyledComponent isBlue />);
 
-        expect(secondContainer.querySelector('span')!.className).toEqual(
-            'foo__3889083325 foo--491189580',
-        );
+            expect(container.querySelector('span')!.className).toEqual(
+                'foo__3826246206 foo--3889083325',
+            );
+        }
+        {
+            const { container } = render(<StyledComponent isBlue isRed />);
+
+            expect(container.querySelector('span')!.className).toEqual(
+                'foo__3826246206 foo--491189580 foo--3889083325',
+            );
+        }
     });
 
     it('returns correct classNames for multiple named modifiers', () => {
         const styles = (props: Props) => styleCollector('foo').element`
             background-color: blue;
-        `.modifier('primary', !!props.isRed)`
+        `.modifier('primary', props.isRed)`
             background-color: red;
-        `.modifier('secondary', !!props.isBlue)`
+        `.modifier('secondary', props.isBlue)`
             background-color: isBlue;
         `;
 
@@ -127,7 +144,7 @@ describe('useStyles', () => {
     it('attaches styles with modifiers to the head', () => {
         const styles = (props: Props) => styleCollector('foo').element`
             background-color: blue;
-        `.modifier(!!props.isRed)`
+        `.modifier(props.isRed)`
             background-color: red;
         `;
 
@@ -149,7 +166,7 @@ describe('useStyles', () => {
     it('attaches styles with named modifiers to the head', () => {
         const styles = (props: Props) => styleCollector('foo').element`
             background-color: blue;
-        `.modifier('primary', !!props.isRed)`
+        `.modifier('primary', props.isRed)`
             background-color: red;
         `;
 
@@ -171,9 +188,9 @@ describe('useStyles', () => {
     it('attaches styles with multiple named modifiers to the head', () => {
         const styles = (props: Props) => styleCollector('foo').element`
             background-color: blue;
-        `.modifier('primary', !!props.isRed)`
+        `.modifier('primary', props.isRed)`
             background-color: red;
-        `.modifier('secondary', !!props.isBlue)`
+        `.modifier('secondary', props.isBlue)`
             background-color: isBlue;
         `;
 
@@ -213,7 +230,7 @@ describe('useStyles', () => {
 
         const styles = (props: Props) => styleCollector<Theme>('foo').element`
             background-color: ${theme => theme.backgroundColor};
-        `.modifier(!!props.isRed)`
+        `.modifier(props.isRed)`
             background-color: ${theme => theme.backgroundColor};
         `;
 

--- a/src/withStyles.spec.tsx
+++ b/src/withStyles.spec.tsx
@@ -42,7 +42,7 @@ describe('withStyles', () => {
     it('returns correct classNames for multiple modifiers', () => {
         const styles = (props: Props) => styleCollector('foo').element`
             background-color: blue;
-        `.modifier(!!props.isRed)`
+        `.modifier(props.isRed)`
             background-color: red;
         `;
 
@@ -88,7 +88,7 @@ describe('withStyles', () => {
     it('attaches styles with modifiers to the head', () => {
         const styles = (props: Props) => styleCollector('foo').element`
             background-color: blue;
-        `.modifier(!!props.isRed)`
+        `.modifier(props.isRed)`
             background-color: red;
         `;
 
@@ -121,7 +121,7 @@ describe('withStyles', () => {
 
         const styles = (props: Props) => styleCollector<Theme>('foo').element`
             background-color: ${theme => theme.backgroundColor};
-        `.modifier(!!props.isRed)`
+        `.modifier(props.isRed)`
             background-color: ${theme => theme.backgroundColor};
         `;
 


### PR DESCRIPTION
Why?

Make the API a lot nicer 

from

```javascript
.modifier(!!props.foo)
```

to...

```
.modifier(props.foo)
```